### PR TITLE
Improve java version handling + ignore root project path for build cache

### DIFF
--- a/src/main/java/org/hibernate/search/develocity/HibernateSearchProjectBuildCacheGradleEnterpriseListener.java
+++ b/src/main/java/org/hibernate/search/develocity/HibernateSearchProjectBuildCacheGradleEnterpriseListener.java
@@ -28,7 +28,7 @@ public class HibernateSearchProjectBuildCacheGradleEnterpriseListener implements
     public void configure(GradleEnterpriseApi gradleEnterpriseApi, MavenSession mavenSession) throws Exception {
         gradleEnterpriseApi.getBuildScan().publishAlways();
         ((BuildScanApiInternal) gradleEnterpriseApi.getBuildScan()).publishIfAuthenticated();
-        BuildScanMetadata.addMetadataToBuildScan(gradleEnterpriseApi.getBuildScan());
+        BuildScanMetadata.addMetadataToBuildScan(gradleEnterpriseApi.getBuildScan(), mavenSession);
 
         Normalization.configureNormalization(gradleEnterpriseApi.getBuildCache());
 

--- a/src/main/java/org/hibernate/search/develocity/SimpleConfiguredPlugin.java
+++ b/src/main/java/org/hibernate/search/develocity/SimpleConfiguredPlugin.java
@@ -3,13 +3,13 @@ package org.hibernate.search.develocity;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.project.MavenProject;
+import java.util.function.Function;
 
 import com.gradle.maven.extension.api.GradleEnterpriseApi;
 import com.gradle.maven.extension.api.cache.MojoMetadataProvider;
 import com.gradle.maven.extension.api.cache.NormalizationProvider;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
 
 
 public abstract class SimpleConfiguredPlugin implements ConfiguredPlugin {
@@ -58,6 +58,20 @@ public abstract class SimpleConfiguredPlugin implements ConfiguredPlugin {
 
     protected static void dependsOnMavenJavaVersion(MojoMetadataProvider.Context.Inputs inputs) {
         inputs.property("_internal_javaVersion", System.getProperty("java.version"));
+    }
+
+    protected static void dependsOnConfigurableJavaExecutable(MojoMetadataProvider.Context.Inputs inputs,
+            MojoMetadataProvider.Context context, String configChildName,
+            Function<String, String> executableToVersion) {
+        var configChild = context.getMojoExecution().getConfiguration().getChild( configChildName );
+        String javaExecutable = configChild == null ? null : configChild.getValue();
+        String javaVersion = executableToVersion.apply( javaExecutable );
+        inputs.property( "_internal_" + configChildName + "_java_version", javaVersion );
+        Log.info(
+                context.getMojoExecution().getPlugin().getArtifactId(),
+				"Using %s at path '%s'; resolved version: %s"
+						.formatted( configChildName, javaExecutable, javaVersion.replace( '\n', ' ' ).trim() )
+        );
     }
 
     @FunctionalInterface

--- a/src/main/java/org/hibernate/search/develocity/normalization/Normalization.java
+++ b/src/main/java/org/hibernate/search/develocity/normalization/Normalization.java
@@ -11,7 +11,8 @@ public final class Normalization {
         // System properties
         buildCacheApi.registerNormalizationProvider(
                 context -> context.configureSystemPropertiesNormalization(s -> {
-                    s.addIgnoredKeys("maven.repo.local", "maven.settings");
+                    s.addIgnoredKeys("maven.repo.local", "maven.settings", "rootProject.directory");
+                    s.addIgnoredKeys("org.hibernate.search.integrationtest.project.root.directory");
                 }));
 
         // Application.properties

--- a/src/main/java/org/hibernate/search/develocity/plugins/CompilerConfiguredPlugin.java
+++ b/src/main/java/org/hibernate/search/develocity/plugins/CompilerConfiguredPlugin.java
@@ -24,16 +24,7 @@ public class CompilerConfiguredPlugin extends SimpleConfiguredPlugin {
 
 	private static void configureCompile(MojoMetadataProvider.Context context) {
 		context.inputs( inputs -> {
-			String executable = context.getMojoExecution().getConfiguration().getAttribute( "executable" );
-			if ( executable == null ) {
-				dependsOnMavenJavaVersion( inputs );
-			}
-			else {
-				inputs.properties(
-						"_internal_executable_version",
-						JavaVersions.forExecutable( executable )
-				);
-			}
+			dependsOnConfigurableJavaExecutable( inputs, context, "executable", JavaVersions::forJavacExecutable );
 		} );
 	}
 }

--- a/src/main/java/org/hibernate/search/develocity/plugins/FailsafeConfiguredPlugin.java
+++ b/src/main/java/org/hibernate/search/develocity/plugins/FailsafeConfiguredPlugin.java
@@ -14,8 +14,7 @@ public class FailsafeConfiguredPlugin extends SurefireConfiguredPlugin {
 	@Override
 	protected Map<String, GoalMetadataProvider> getGoalMetadataProviders() {
 		return Map.of(
-				"integration-test", FailsafeConfiguredPlugin::configureIntegrationTest,
-				"verify", FailsafeConfiguredPlugin::configureIntegrationTest
+				"integration-test", FailsafeConfiguredPlugin::configureIntegrationTest
 		);
 	}
 

--- a/src/main/java/org/hibernate/search/develocity/plugins/SurefireConfiguredPlugin.java
+++ b/src/main/java/org/hibernate/search/develocity/plugins/SurefireConfiguredPlugin.java
@@ -23,16 +23,7 @@ public class SurefireConfiguredPlugin extends SimpleConfiguredPlugin {
 
 	protected static void configureTest(MojoMetadataProvider.Context context) {
 		context.inputs( inputs -> {
-			String jvm = context.getMojoExecution().getConfiguration().getAttribute( "jvm" );
-			if ( jvm == null ) {
-				dependsOnMavenJavaVersion( inputs );
-			}
-			else {
-				inputs.properties(
-						"_internal_jvm_version",
-						JavaVersions.forExecutable( jvm )
-				);
-			}
+			dependsOnConfigurableJavaExecutable( inputs, context, "jvm", JavaVersions::forJavaExecutable );
 		} );
 	}
 }

--- a/src/main/java/org/hibernate/search/develocity/scan/BuildScanMetadata.java
+++ b/src/main/java/org/hibernate/search/develocity/scan/BuildScanMetadata.java
@@ -2,20 +2,38 @@ package org.hibernate.search.develocity.scan;
 
 import static org.hibernate.search.develocity.util.Strings.isBlank;
 
+import java.util.function.Function;
+
+import org.hibernate.search.develocity.Log;
+import org.hibernate.search.develocity.util.JavaVersions;
+
 import com.gradle.maven.extension.api.scan.BuildScanApi;
+import org.apache.maven.execution.MavenSession;
 
 public final class BuildScanMetadata {
 
-    private BuildScanMetadata() {
-    }
+	private BuildScanMetadata() {
+	}
 
-    public static void addMetadataToBuildScan(BuildScanApi buildScanApi) {
-        // Add mvn command line
-        final String mavenCommandLine = System.getenv("MAVEN_CMD_LINE_ARGS") != null ? "mvn " + System.getenv("MAVEN_CMD_LINE_ARGS") : "";
-        if (!isBlank(mavenCommandLine)) {
-            buildScanApi.value("Maven command line", "mvn " + mavenCommandLine);
-        }
+	public static void addMetadataToBuildScan(BuildScanApi buildScanApi, MavenSession mavenSession) {
+		// Add mvn command line
+		final String mavenCommandLine = System.getenv( "MAVEN_CMD_LINE_ARGS" ) != null ? "mvn " + System.getenv(
+				"MAVEN_CMD_LINE_ARGS" ) : "";
+		if ( !isBlank( mavenCommandLine ) ) {
+			buildScanApi.value( "Maven command line", "mvn " + mavenCommandLine );
+		}
 
-        buildScanApi.tag("hibernate-search");
-    }
+		buildScanApi.tag( "hibernate-search" );
+
+		recordExecutableVersion( buildScanApi, mavenSession, "java-version.main.compiler", JavaVersions::forJavacExecutable );
+		recordExecutableVersion( buildScanApi, mavenSession, "java-version.test.compiler", JavaVersions::forJavacExecutable );
+		recordExecutableVersion( buildScanApi, mavenSession, "java-version.test.launcher", JavaVersions::forJavaExecutable );
+	}
+
+	private static void recordExecutableVersion(BuildScanApi buildScanApi, MavenSession mavenSession,
+			String propertyName, Function<String, String> executableToVersion) {
+		String javaExecutable = (String) mavenSession.getResult().getProject().getProperties().get( propertyName );
+		String javaVersion = executableToVersion.apply( javaExecutable );
+		buildScanApi.value( propertyName, "Path: %s\nResolved version: %s".formatted( javaExecutable, javaVersion ) );
+	}
 }


### PR DESCRIPTION
With this, we successfully use different caches depending on the exact java version, and integration tests seem to get cached too (I just checked mapper-pojo-base though, we'd need to test a full run).