### PR TITLE
Use fully-resolved properties/config to determine build metadata

### DIFF
--- a/src/main/java/org/hibernate/search/develocity/GoalMetadataProvider.java
+++ b/src/main/java/org/hibernate/search/develocity/GoalMetadataProvider.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  * Hibernate Search, full-text search for your domain model
+ *  *
+ *  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ *  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ *
+ */
+package org.hibernate.search.develocity;
+
+import org.hibernate.search.develocity.util.MavenMojoExecutionConfig;
+import org.hibernate.search.develocity.util.MavenProperties;
+
+import com.gradle.maven.extension.api.cache.MojoMetadataProvider;
+import com.gradle.maven.extension.api.scan.BuildScanApi;
+
+@FunctionalInterface
+public interface GoalMetadataProvider {
+	void configure(Context context);
+
+	class Context {
+		private final BuildScanApi buildScanApi;
+		private final MojoMetadataProvider.Context metadataContext;
+		private final MavenProperties properties;
+		private final MavenMojoExecutionConfig configuration;
+
+
+		public Context(BuildScanApi buildScanApi, MojoMetadataProvider.Context metadataContext) {
+			this.buildScanApi = buildScanApi;
+			this.metadataContext = metadataContext;
+			this.properties = new MavenProperties( metadataContext.getSession(), metadataContext.getMojoExecution() );
+			this.configuration = new MavenMojoExecutionConfig( metadataContext.getMojoExecution() );
+		}
+
+		public BuildScanApi buildScan() {
+			return buildScanApi;
+		}
+
+		public MojoMetadataProvider.Context metadata() {
+			return metadataContext;
+		}
+
+		public MavenProperties properties() {
+			return properties;
+		}
+
+		public MavenMojoExecutionConfig configuration() {
+			return configuration;
+		}
+
+		public void buildScanDeduplicatedValue(String key, String value) {
+			buildScanApi.executeOnce( key + value, ignored -> buildScanApi.value( key, value ) );
+		}
+	}
+}

--- a/src/main/java/org/hibernate/search/develocity/HibernateSearchProjectDevelocityListener.java
+++ b/src/main/java/org/hibernate/search/develocity/HibernateSearchProjectDevelocityListener.java
@@ -26,10 +26,11 @@ public class HibernateSearchProjectDevelocityListener implements GradleEnterpris
 
 
     @Override
-    public void configure(GradleEnterpriseApi gradleEnterpriseApi, MavenSession mavenSession) throws Exception {
+    public void configure(GradleEnterpriseApi gradleEnterpriseApi, MavenSession mavenSession) {
         gradleEnterpriseApi.getBuildScan().publishAlways();
         ((BuildScanApiInternal) gradleEnterpriseApi.getBuildScan()).publishIfAuthenticated();
-        BuildScanMetadata.addMetadataToBuildScan(gradleEnterpriseApi.getBuildScan(), mavenSession);
+
+        BuildScanMetadata.addMainMetadata(gradleEnterpriseApi.getBuildScan());
 
         Normalization.configureNormalization(gradleEnterpriseApi.getBuildCache());
 

--- a/src/main/java/org/hibernate/search/develocity/SimpleConfiguredPlugin.java
+++ b/src/main/java/org/hibernate/search/develocity/SimpleConfiguredPlugin.java
@@ -5,13 +5,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
 
+import org.hibernate.search.develocity.scan.BuildScanMetadata;
 import org.hibernate.search.develocity.util.JavaVersions;
-import org.hibernate.search.develocity.util.MavenConfigs;
 
 import com.gradle.maven.extension.api.GradleEnterpriseApi;
 import com.gradle.maven.extension.api.cache.MojoMetadataProvider;
-import com.gradle.maven.extension.api.cache.NormalizationProvider;
-import com.gradle.maven.extension.api.scan.BuildScanApi;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 
@@ -27,16 +25,17 @@ public abstract class SimpleConfiguredPlugin implements ConfiguredPlugin {
                     return;
                 }
 
-                Map<String, GoalMetadataProvider> goalMetadataProviders = Collections.unmodifiableMap(getGoalMetadataProviders(gradleEnterpriseApi.getBuildScan()));
+                Map<String, GoalMetadataProvider> goalMetadataProviders = Collections.unmodifiableMap(getGoalMetadataProviders());
 
                 Log.debug(getPluginName(), "Build cache is enabled. Configuring metadata providers.");
                 Log.debug(getPluginName(), "Configuring metadata for goals: " + goalMetadataProviders.keySet());
 
-                for (Entry<String, GoalMetadataProvider> goalMetadataProviderEntry : goalMetadataProviders.entrySet()) {
-                    if (goalMetadataProviderEntry.getKey().equalsIgnoreCase(context.getMojoExecution().getGoal())) {
-                        goalMetadataProviderEntry.getValue().configure(context);
-                    }
-                }
+				for ( Entry<String, GoalMetadataProvider> goalMetadataProviderEntry : goalMetadataProviders.entrySet() ) {
+					if ( goalMetadataProviderEntry.getKey().equalsIgnoreCase( context.getMojoExecution().getGoal() ) ) {
+						goalMetadataProviderEntry.getValue()
+								.configure( new GoalMetadataProvider.Context( gradleEnterpriseApi.getBuildScan(), context ) );
+					}
+				}
             });
         });
     }
@@ -47,10 +46,11 @@ public abstract class SimpleConfiguredPlugin implements ConfiguredPlugin {
         return true;
     }
 
-    protected abstract Map<String, GoalMetadataProvider> getGoalMetadataProviders(BuildScanApi buildScanApi);
+    protected abstract Map<String, GoalMetadataProvider> getGoalMetadataProviders();
 
-    protected static void dependsOnGav(MojoMetadataProvider.Context.Inputs inputs, MojoMetadataProvider.Context context) {
-        inputs.property("_internal_gav", context.getProject().getGroupId() + ":" + context.getProject().getArtifactId() + ":" + context.getProject().getVersion());
+    protected static void dependsOnGav(MojoMetadataProvider.Context.Inputs inputs, GoalMetadataProvider.Context context) {
+		var project = context.metadata().getProject();
+        inputs.property("_internal_gav", project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion());
     }
 
 
@@ -65,31 +65,24 @@ public abstract class SimpleConfiguredPlugin implements ConfiguredPlugin {
     }
 
     protected static void dependsOnConfigurableJavaExecutable(MojoMetadataProvider.Context.Inputs inputs,
-            MojoMetadataProvider.Context context, String configChildName,
+			GoalMetadataProvider.Context context, String configChildName, Boolean skipped,
             Function<String, String> executableToVersion) {
-        var configChild = context.getMojoExecution().getConfiguration().getChild( configChildName );
-        String javaExecutable = configChild == null ? null : configChild.getValue();
+		String javaExecutable = context.configuration().getString( configChildName );
 		String javaVersion = executableToVersion.apply( javaExecutable );
+		boolean canCacheExactVersion = context.properties().cacheExactJavaVersion();
 		inputs.property( "_internal_" + configChildName + "_java_version",
-				MavenConfigs.cacheExactJavaVersion( context.getSession() )
+				canCacheExactVersion
 						? javaVersion
 						: JavaVersions.toJdkMajor( javaVersion, javaVersion ) );
-		Log.info(
-                context.getMojoExecution().getPlugin().getArtifactId(),
-				"Using %s at path '%s'; resolved version: %s"
-						.formatted( configChildName, javaExecutable, javaVersion.replace( '\n', ' ' ).trim() )
-        );
+
+		if ( skipped == null || !skipped ) {
+			BuildScanMetadata.addJavaExecutableVersion( context, javaExecutable, javaVersion, canCacheExactVersion );
+			Log.info(
+					context.metadata().getMojoExecution().getPlugin().getArtifactId(),
+					"Using %s at path '%s'; resolved version: %s"
+							.formatted( configChildName, javaExecutable, javaVersion.replace( '\n', ' ' ).trim() )
+			);
+		}
     }
 
-    @FunctionalInterface
-    public interface PluginNormalizationProvider {
-
-        void configure(NormalizationProvider.Context context);
-    }
-
-    @FunctionalInterface
-    public interface GoalMetadataProvider {
-
-        void configure(MojoMetadataProvider.Context context);
-    }
 }

--- a/src/main/java/org/hibernate/search/develocity/plugins/CompilerConfiguredPlugin.java
+++ b/src/main/java/org/hibernate/search/develocity/plugins/CompilerConfiguredPlugin.java
@@ -2,11 +2,9 @@ package org.hibernate.search.develocity.plugins;
 
 import java.util.Map;
 
+import org.hibernate.search.develocity.GoalMetadataProvider;
 import org.hibernate.search.develocity.SimpleConfiguredPlugin;
 import org.hibernate.search.develocity.util.JavaVersions;
-
-import com.gradle.maven.extension.api.cache.MojoMetadataProvider;
-import com.gradle.maven.extension.api.scan.BuildScanApi;
 
 public class CompilerConfiguredPlugin extends SimpleConfiguredPlugin {
 
@@ -16,16 +14,19 @@ public class CompilerConfiguredPlugin extends SimpleConfiguredPlugin {
 	}
 
 	@Override
-	protected Map<String, GoalMetadataProvider> getGoalMetadataProviders(BuildScanApi buildScanApi) {
+	protected Map<String, GoalMetadataProvider> getGoalMetadataProviders() {
 		return Map.of(
 				"compile", CompilerConfiguredPlugin::configureCompile,
 				"testCompile", CompilerConfiguredPlugin::configureCompile
 		);
 	}
 
-	private static void configureCompile(MojoMetadataProvider.Context context) {
-		context.inputs( inputs -> {
-			dependsOnConfigurableJavaExecutable( inputs, context, "executable", JavaVersions::forJavacExecutable );
+	private static void configureCompile(GoalMetadataProvider.Context context) {
+		var metadata = context.metadata();
+		metadata.inputs( inputs -> {
+			dependsOnConfigurableJavaExecutable( inputs, context, "executable",
+					context.configuration().getBoolean( "skip" ),
+					JavaVersions::forJavacExecutable );
 		} );
 	}
 }

--- a/src/main/java/org/hibernate/search/develocity/plugins/EnforcerConfiguredPlugin.java
+++ b/src/main/java/org/hibernate/search/develocity/plugins/EnforcerConfiguredPlugin.java
@@ -3,10 +3,8 @@ package org.hibernate.search.develocity.plugins;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.hibernate.search.develocity.GoalMetadataProvider;
 import org.hibernate.search.develocity.SimpleConfiguredPlugin;
-
-import com.gradle.maven.extension.api.cache.MojoMetadataProvider;
-import com.gradle.maven.extension.api.scan.BuildScanApi;
 
 public class EnforcerConfiguredPlugin extends SimpleConfiguredPlugin {
 
@@ -16,20 +14,21 @@ public class EnforcerConfiguredPlugin extends SimpleConfiguredPlugin {
     }
 
     @Override
-    protected Map<String, GoalMetadataProvider> getGoalMetadataProviders(BuildScanApi buildScanApi) {
+    protected Map<String, GoalMetadataProvider> getGoalMetadataProviders() {
         return Map.of(
                 "enforce", EnforcerConfiguredPlugin::configureEnforce);
     }
 
-    private static void configureEnforce(MojoMetadataProvider.Context context) {
-        context.inputs(inputs -> {
+    private static void configureEnforce(GoalMetadataProvider.Context context) {
+        var metadata = context.metadata();
+        metadata.inputs(inputs -> {
             dependsOnGav(inputs, context);
             inputs.properties("skip", "fail", "failFast", "failIfNoRules", "rules", "rulesToExecute", "rulesToSkip",
                     "ignoreCache");
             dependsOnOs(inputs);
             dependsOnMavenJavaVersion(inputs);
 
-            String dependencies = context.getProject().getArtifacts().stream()
+            String dependencies = metadata.getProject().getArtifacts().stream()
                     .map(a -> a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getVersion() + ":" + a.getClassifier())
                     .sorted()
                     .collect(Collectors.joining("\n"));
@@ -39,7 +38,7 @@ public class EnforcerConfiguredPlugin extends SimpleConfiguredPlugin {
             inputs.ignore("project", "mojoExecution", "session");
         });
 
-        context.outputs(outputs -> {
+        metadata.outputs(outputs -> {
             outputs.cacheable("If the inputs and dependencies are identical, we should have the same output");
         });
     }

--- a/src/main/java/org/hibernate/search/develocity/plugins/ImpsortConfiguredPlugin.java
+++ b/src/main/java/org/hibernate/search/develocity/plugins/ImpsortConfiguredPlugin.java
@@ -2,12 +2,11 @@ package org.hibernate.search.develocity.plugins;
 
 import java.util.Map;
 
+import org.hibernate.search.develocity.GoalMetadataProvider;
 import org.hibernate.search.develocity.SimpleConfiguredPlugin;
 
-import com.gradle.maven.extension.api.cache.MojoMetadataProvider;
 import com.gradle.maven.extension.api.cache.MojoMetadataProvider.Context.FileSet.EmptyDirectoryHandling;
 import com.gradle.maven.extension.api.cache.MojoMetadataProvider.Context.FileSet.NormalizationStrategy;
-import com.gradle.maven.extension.api.scan.BuildScanApi;
 
 public class ImpsortConfiguredPlugin extends SimpleConfiguredPlugin {
 
@@ -17,7 +16,7 @@ public class ImpsortConfiguredPlugin extends SimpleConfiguredPlugin {
     }
 
     @Override
-    protected Map<String, GoalMetadataProvider> getGoalMetadataProviders(BuildScanApi buildScanApi) {
+    protected Map<String, GoalMetadataProvider> getGoalMetadataProviders() {
         return Map.of(
                 "sort", ImpsortConfiguredPlugin::configureSort,
                 "check", ImpsortConfiguredPlugin::configureValidate);
@@ -25,8 +24,10 @@ public class ImpsortConfiguredPlugin extends SimpleConfiguredPlugin {
 
     // This is for AbstractImpSortMojo, extended by CheckMojo and SortMojo
     // See https://github.com/revelc/impsort-maven-plugin/tree/main/src/main/java/net/revelc/code/impsort/maven/plugin
-    private static void configureCommon(MojoMetadataProvider.Context context) {
-        context.inputs(inputs -> {
+    private static void configureCommon(GoalMetadataProvider.Context context) {
+        var metadata = context.metadata();
+
+        metadata.inputs(inputs -> {
             dependsOnGav(inputs, context);
 
             inputs.properties("sourceEncoding", "skip", "staticGroups", "groups", "staticAfter", "joinStaticWithNonStatic",
@@ -43,26 +44,32 @@ public class ImpsortConfiguredPlugin extends SimpleConfiguredPlugin {
             inputs.ignore("project", "plugin",
                     // For now, we need to ignore the cachedir until we can declare it as an output. See below.
                     "cachedir");
+        });
 
-            context.outputs(outputs -> {
-                // For now we don't want to output the cachedir as it contains absolute paths
-                // See https://github.com/revelc/impsort-maven-plugin/pull/87
-                //outputs.directory("cachedir");
-            });
+        metadata.outputs(outputs -> {
+            // For now we don't want to output the cachedir as it contains absolute paths
+            // See https://github.com/revelc/impsort-maven-plugin/pull/87
+            //outputs.directory("cachedir");
         });
     }
 
-    private static void configureSort(MojoMetadataProvider.Context context) {
-        configureCommon(context);
-        context.outputs(outputs -> {
-            outputs.cacheable("If the inputs and dependencies are identical, we should have the same output");
-        });
-    }
+	private static void configureSort(GoalMetadataProvider.Context context) {
+		var metadata = context.metadata();
 
-    private static void configureValidate(MojoMetadataProvider.Context context) {
-        configureCommon(context);
-        context.outputs(outputs -> {
-            outputs.cacheable("If the inputs and dependencies are identical, we should have the same output");
-        });
-    }
+		configureCommon( context );
+
+		metadata.outputs( outputs -> {
+			outputs.cacheable( "If the inputs and dependencies are identical, we should have the same output" );
+		} );
+	}
+
+	private static void configureValidate(GoalMetadataProvider.Context context) {
+		var metadata = context.metadata();
+
+		configureCommon( context );
+
+		metadata.outputs( outputs -> {
+			outputs.cacheable( "If the inputs and dependencies are identical, we should have the same output" );
+		} );
+	}
 }

--- a/src/main/java/org/hibernate/search/develocity/plugins/SourceConfiguredPlugin.java
+++ b/src/main/java/org/hibernate/search/develocity/plugins/SourceConfiguredPlugin.java
@@ -3,11 +3,10 @@ package org.hibernate.search.develocity.plugins;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.hibernate.search.develocity.GoalMetadataProvider;
 import org.hibernate.search.develocity.SimpleConfiguredPlugin;
 
-import com.gradle.maven.extension.api.cache.MojoMetadataProvider;
 import com.gradle.maven.extension.api.cache.MojoMetadataProvider.Context.FileSet.NormalizationStrategy;
-import com.gradle.maven.extension.api.scan.BuildScanApi;
 
 /**
  * TODO discuss this more in depth with Alexey, especially to make sure the output directory is not shared with other plugins.
@@ -20,32 +19,35 @@ public class SourceConfiguredPlugin extends SimpleConfiguredPlugin {
     }
 
     @Override
-    protected Map<String, GoalMetadataProvider> getGoalMetadataProviders(BuildScanApi buildScanApi) {
+    protected Map<String, GoalMetadataProvider> getGoalMetadataProviders() {
         return Map.of(
                 "jar-no-fork", SourceConfiguredPlugin::jarNoFork);
     }
 
-    private static void jarNoFork(MojoMetadataProvider.Context context) {
-        context.inputs(inputs -> {
+    private static void jarNoFork(GoalMetadataProvider.Context context) {
+        var metadata = context.metadata();
+        var project = metadata.getProject();
+
+        metadata.inputs(inputs -> {
             dependsOnGav(inputs, context);
 
             inputs.properties("classifier", "includes", "excludes", "useDefaultExcludes",
                     "useDefaultManifestFile", "attach", "excludeResources", "includePom", "finalName", "forceCreation",
                     "skipSource", "outputTimestamp");
             inputs.fileSet("defaultManifestFile", fileSet -> fileSet.normalizationStrategy(NormalizationStrategy.RELATIVE_PATH));
-            inputs.fileSet("resources", context.getProject().getResources().stream().map(r -> r.getDirectory())
+            inputs.fileSet("resources", project.getResources().stream().map(r -> r.getDirectory())
                     .collect(Collectors.toList()),
                     fileSet -> fileSet.normalizationStrategy(NormalizationStrategy.RELATIVE_PATH));
-            inputs.fileSet("sources", context.getProject().getCompileSourceRoots(),
+            inputs.fileSet("sources", project.getCompileSourceRoots(),
                     fileSet -> fileSet.normalizationStrategy(NormalizationStrategy.RELATIVE_PATH));
 
             inputs.ignore("project", "jarArchiver", "archive", "outputDirectory", "reactorProjects", "session");
         });
 
-        context.outputs(outputs -> {
+        metadata.outputs(outputs -> {
             outputs.cacheable("If the inputs are identical, we should have the same output");
-            outputs.file("source-jar", context.getProject().getBuild().getDirectory() + "/"
-                    + context.getProject().getBuild().getFinalName() + "-sources.jar");
+            outputs.file("source-jar", project.getBuild().getDirectory() + "/"
+                    + project.getBuild().getFinalName() + "-sources.jar");
         });
     }
 }

--- a/src/main/java/org/hibernate/search/develocity/scan/BuildScanMetadata.java
+++ b/src/main/java/org/hibernate/search/develocity/scan/BuildScanMetadata.java
@@ -6,18 +6,15 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 
+import org.hibernate.search.develocity.GoalMetadataProvider;
 import org.hibernate.search.develocity.Log;
 import org.hibernate.search.develocity.util.JavaVersions;
-import org.hibernate.search.develocity.util.MavenConfigs;
+import org.hibernate.search.develocity.util.MavenProperties;
 import org.hibernate.search.develocity.util.Strings;
 
 import com.gradle.maven.extension.api.scan.BuildScanApi;
-
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.MojoExecution;
 
 public final class BuildScanMetadata {
 
@@ -28,7 +25,7 @@ public final class BuildScanMetadata {
 	private BuildScanMetadata() {
 	}
 
-	public static void addMetadataToBuildScan(BuildScanApi buildScanApi, MavenSession mavenSession) {
+	public static void addMainMetadata(BuildScanApi buildScanApi) {
 		// Add mvn command line
 		final String mavenCommandLine = System.getenv( "MAVEN_CMD_LINE_ARGS" ) != null
 				? "mvn " + System.getenv(
@@ -39,25 +36,31 @@ public final class BuildScanMetadata {
 		}
 
 		buildScanApi.tag( "hibernate-search" );
-
-		buildScanApi.value( MavenConfigs.BUILD_CACHE_JAVA_VERSION_EXACT,
-				String.valueOf( MavenConfigs.cacheExactJavaVersion( mavenSession ) ) );
-
-		recordExecutableVersion( buildScanApi, mavenSession, "java-version.main.compiler", false,
-				JavaVersions::forJavacExecutable );
-		recordExecutableVersion( buildScanApi, mavenSession, "java-version.test.compiler", false,
-				JavaVersions::forJavacExecutable );
-		recordExecutableVersion( buildScanApi, mavenSession, "java-version.test.launcher", true,
-				JavaVersions::forJavaExecutable );
 	}
 
-	public static void addFailsafeMetadataToBuildScan(BuildScanApi buildScanApi, MavenSession mavenSession,
-			MojoExecution mojoExecution) {
-		var project = mavenSession.getCurrentProject();
+	public static void addJavaExecutableVersion(GoalMetadataProvider.Context context,
+			String javaExecutable, String javaVersion,
+			boolean canCacheExactVersion) {
+		context.buildScanDeduplicatedValue( MavenProperties.BUILD_CACHE_JAVA_VERSION_EXACT,
+				String.valueOf( canCacheExactVersion ) );
+		var buildScanApi = context.buildScan();
+		String plugin = context.metadata().getMojoExecution().getArtifactId();
+		if ( plugin.equals( "maven-surefire-plugin" ) || plugin.equals( "maven-failsafe-plugin" ) ) {
+			buildScanApi.tag( "jdk-%s".formatted( JavaVersions.toJdkMajor( javaVersion, "unknown" ) ) );
+		}
+
+		String goal = context.metadata().getMojoExecution().getGoal();
+		context.buildScanDeduplicatedValue( "%s.%s.jdk".formatted( plugin, goal ), "Path: %s\nResolved version: %s".formatted( javaExecutable, javaVersion ) );
+	}
+
+	public static void addFailsafeMetadata(GoalMetadataProvider.Context context) {
+		var buildScanApi = context.buildScan();
+
+		var project = context.metadata().getProject();
 		boolean dependsOnOrm = false;
 		boolean dependsOnLucene = false;
 		boolean dependsOnElasticsearch = false;
-		var artifactFilter = MavenConfigs.getFailsafeClasspathFilter( mojoExecution );
+		var artifactFilter = context.configuration().getFailsafeClasspathFilter();
 		for ( var dependency : project.getArtifacts() ) {
 			if ( !artifactFilter.include( dependency ) ) {
 				continue;
@@ -69,44 +72,46 @@ public final class BuildScanMetadata {
 		}
 
 		if ( dependsOnOrm ) {
-			var dbKind = MavenConfigs.getStringProperty( mavenSession, "test.database.run.kind" );
+			var dbKind = context.properties().getString( "test.database.run.kind" );
 			if ( !Strings.isBlank( dbKind ) ) {
 				if ( dbKind.equals( "h2" ) ) {
 					// H2 doesn't use containers
 					buildScanApi.tag( "h2" );
 				}
 				else {
-					tagDockerfileShortImageRef( buildScanApi, mavenSession,
+					addDockerfileShortImageRef( context,
 							"database/%s.Dockerfile".formatted( dbKind ), null );
 				}
 			}
 		}
 
-		String explicitBackend =
-				MavenConfigs.getFailsafeSystemProperty( mojoExecution, "org.hibernate.search.integrationtest.backend.type" );
+		String explicitBackend = context.configuration()
+				.getFailsafeSystemProperty( "org.hibernate.search.integrationtest.backend.type" );
 		if ( Strings.isBlank( explicitBackend ) ) {
 			explicitBackend = null;
 		}
 
 		if ( dependsOnLucene
 				&& ( explicitBackend == null || "lucene".equals( explicitBackend ) )
-				&& !MavenConfigs.getBooleanProperty( project, "test.lucene.skip" ) ) {
+				&& !context.properties().getBoolean( "test.lucene.skip" ) ) {
 			buildScanApi.tag( "lucene" );
 		}
 
 		if ( dependsOnElasticsearch
 				&& ( explicitBackend == null || "elasticsearch".equals( explicitBackend ) )
-				&& !MavenConfigs.getBooleanProperty( project, "test.elasticsearch.skip" ) ) {
-			var distribution = MavenConfigs.getStringProperty( mavenSession, "test.elasticsearch.distribution" );
-			tagDockerfileShortImageRef( buildScanApi, mavenSession,
+				&& !context.properties().getBoolean( "test.elasticsearch.skip" ) ) {
+			var distribution = context.properties().getString( "test.elasticsearch.distribution" );
+			addDockerfileShortImageRef( context,
 					"search-backend/%s.Dockerfile".formatted( distribution ),
-					MavenConfigs.getStringProperty( mavenSession, "test.elasticsearch.version" ) );
+					context.properties().getString( "test.elasticsearch.version" ) );
 		}
 	}
 
-	private static void tagDockerfileShortImageRef(BuildScanApi buildScanApi, MavenSession mavenSession,
+	private static void addDockerfileShortImageRef(GoalMetadataProvider.Context context,
 			String dockerfileRelativePath, String versionOverride) {
-		var path = Path.of( mavenSession.getExecutionRootDirectory(), "build/container", dockerfileRelativePath );
+		var buildScanApi = context.buildScan();
+		var path = Path.of( context.metadata().getSession().getExecutionRootDirectory(),
+				"build/container", dockerfileRelativePath );
 		try {
 			String ref;
 			try ( var stream = Files.lines( path ) ) {
@@ -146,16 +151,6 @@ public final class BuildScanMetadata {
 		else {
 			return ref;
 		}
-	}
-
-	private static void recordExecutableVersion(BuildScanApi buildScanApi, MavenSession mavenSession,
-			String propertyName, boolean tag, Function<String, String> executableToVersion) {
-		String javaExecutable = MavenConfigs.getStringProperty( mavenSession, propertyName );
-		String javaVersion = executableToVersion.apply( javaExecutable );
-		if ( tag ) {
-			buildScanApi.tag( "jdk-%s".formatted( JavaVersions.toJdkMajor( javaVersion, "unknown" ) ) );
-		}
-		buildScanApi.value( propertyName, "Path: %s\nResolved version: %s".formatted( javaExecutable, javaVersion ) );
 	}
 
 }

--- a/src/main/java/org/hibernate/search/develocity/util/MavenProperties.java
+++ b/src/main/java/org/hibernate/search/develocity/util/MavenProperties.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  * Hibernate Search, full-text search for your domain model
+ *  *
+ *  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ *  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ *
+ */
+package org.hibernate.search.develocity.util;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+
+public final class MavenProperties {
+
+	public static final String BUILD_CACHE_JAVA_VERSION_EXACT = "build-cache.java-version.exact";
+
+	private final PluginParameterExpressionEvaluator evaluator;
+
+	public MavenProperties(MavenSession session, MojoExecution mojoExecution) {
+		this.evaluator = new PluginParameterExpressionEvaluator( session, mojoExecution );
+	}
+
+	public Boolean getBoolean(String key) {
+		return Boolean.parseBoolean( getString( key ) );
+	}
+
+	public String getString(String key) {
+		return (String) get( key );
+	}
+
+	public Object get(String key) {
+		try {
+			return evaluator.evaluate( "${" + key + "}" );
+		}
+		catch (ExpressionEvaluationException e) {
+			throw new RuntimeException( "Could not get value for %s: %s".formatted( key, e.getMessage() ), e );
+		}
+	}
+
+	public boolean cacheExactJavaVersion() {
+		return getBoolean( BUILD_CACHE_JAVA_VERSION_EXACT );
+	}
+}


### PR DESCRIPTION
Fixes problems with tags/values being added in the wrong module or with
the wrong value, because we were not considering user overrides or
per-module overrides.
